### PR TITLE
refactor(email-verification): Add send-verification-email endpoint in…

### DIFF
--- a/backend/src/main/java/com/project/G1_T3/authentication/service/JwtService.java
+++ b/backend/src/main/java/com/project/G1_T3/authentication/service/JwtService.java
@@ -75,15 +75,8 @@ public class JwtService {
                 throw new InvalidTokenException("Invalid token purpose", token);
             }
 
-            if (claims.getExpiration().before(new Date())) {
-                throw new InvalidTokenException("Token has expired", token);
-            }
-
             return claims.getSubject();
-
-        } catch (ExpiredJwtException e) {
-            throw new InvalidTokenException("Token has expired", token);
-        } catch (MalformedJwtException e) {
+        } catch (MalformedJwtException | ExpiredJwtException e) {
             throw e;
         } catch (JwtException | IllegalArgumentException e) {
             throw new InvalidTokenException("Invalid token", token);

--- a/backend/src/main/java/com/project/G1_T3/user/service/UserService.java
+++ b/backend/src/main/java/com/project/G1_T3/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.project.G1_T3.user.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ public class UserService {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
-    
+
     @Autowired
     private PlayerProfileService playerProfileService;
 
@@ -69,11 +70,11 @@ public class UserService {
 
         // Send verification email
         User savedUser = userRepository.save(newUser);
-        
+
         if (newUser.getRole() == UserRole.PLAYER) {
             sendVerificationEmail(newUser);
         }
-        
+
         // Create and save a new PlayerProfile
         PlayerProfile newProfile = new PlayerProfile();
         newProfile.setUserId(savedUser.getId());
@@ -117,6 +118,18 @@ public class UserService {
         String token = jwtService.generateEmailVerificationToken(user);
         String verificationLink = backendUrl + "/authentication/verify-email?token=" + token;
         emailService.sendVerificationEmail(user.getEmail(), user.getUsername(), verificationLink);
+    }
+
+    public void sendVerificationEmailByUserId(String uuid) {
+
+        Optional<User> userOptional = userRepository.findById(UUID.fromString(uuid));
+
+        if (!userOptional.isPresent()) {
+            throw new UsernameNotFoundException(uuid);
+        }
+
+        User user = userOptional.get();
+        sendVerificationEmail(user);
     }
 
 }

--- a/backend/src/test/java/com/project/G1_T3/authentication/service/JwtServiceTest.java
+++ b/backend/src/test/java/com/project/G1_T3/authentication/service/JwtServiceTest.java
@@ -8,6 +8,7 @@ import com.project.G1_T3.common.exception.InvalidTokenException;
 import com.project.G1_T3.user.model.CustomUserDetails;
 import com.project.G1_T3.user.model.User;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -149,9 +150,8 @@ class JwtServiceTest {
                 .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(TEST_SECRET_KEY)), SignatureAlgorithm.HS256)
                 .compact();
 
-        InvalidTokenException exception = assertThrows(InvalidTokenException.class,
+        assertThrows(ExpiredJwtException.class,
                 () -> jwtService.validateEmailVerificationToken(token));
-        assertEquals("Token has expired", exception.getMessage());
     }
 
     @Test

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -115,6 +115,8 @@ const Login: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
     const router = useRouter();
     const { login } = useAuth();
+    const searchParams = useSearchParams();
+    const redirectUrl = searchParams.get("redirect") || null;
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -123,10 +125,15 @@ const Login: React.FC = () => {
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setError(null);
+
+        const { username, password } = formData;
+
         try {
-            const { user, response } = await login(formData.username, formData.password);
+            const { user, response } = await login(username, password);
+
             if (response.status === 200) {
-                router.push(user?.role === "ADMIN" ? "/admin/dashboard" : "/profile");
+                const destination = redirectUrl ?? (user?.role === "ADMIN" ? "/admin/dashboard" : "/profile");
+                router.push(destination);
             }
         } catch (error: any) {
             if (error?.response?.data) {


### PR DESCRIPTION
… the scenario where the token has expired

- Updated JwtService to handle expired tokens by catching ExpiredJwtException and redirecting to the verification-failed page.
- Added a new method sendVerificationEmailByUserId in UserService to send a verification email by user ID.
- Modified the verifyEmail method in AuthenticationController to handle expired tokens and redirect to the verification-failed page.
- Added a new endpoint /send-verification-email in AuthenticationController to send a verification email by user ID.
- Updated the frontend login page to handle a redirect URL parameter and added a button to resend the verification email.
- Created a new frontend page verification-failed to handle the case when the verification token has expired.